### PR TITLE
Update SymbolicLinkReparseData.cs

### DIFF
--- a/SymbolicLinkSupport/SymbolicLinkReparseData.cs
+++ b/SymbolicLinkSupport/SymbolicLinkReparseData.cs
@@ -8,8 +8,7 @@ namespace SymbolicLinkSupport
     [StructLayout(LayoutKind.Sequential)]
     internal struct SymbolicLinkReparseData
     {
-        // Not certain about this!
-        private const int maxUnicodePathLength = 260 * 2;
+        private const int maxUnicodePathLength = 32767 * 2;
 
         public uint ReparseTag;
         public ushort ReparseDataLength;


### PR DESCRIPTION
Max path length is 32767.

"The Windows API has many functions that also have Unicode versions to permit an extended-length path for a maximum total path length of 32,767 characters. This type of path is composed of components separated by backslashes, each up to the value returned in the lpMaximumComponentLength parameter of the GetVolumeInformation function (this value is commonly 255 characters). To specify an extended-length path, use the "\\?\" prefix. For example, "\\?\D:\very long path"."

https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file