### PR TITLE
Topic/relative links+fixes

### DIFF
--- a/SymbolicLinkSupport/DirectoryInfoExtensions.cs
+++ b/SymbolicLinkSupport/DirectoryInfoExtensions.cs
@@ -36,7 +36,7 @@ namespace SymbolicLinkSupport
         /// <exception cref="System.ArgumentException">If the directory is not a symbolic link.</exception>
         public static bool IsSymbolicLinkValid(this DirectoryInfo directoryInfo)
         {
-            return File.Exists(directoryInfo.GetSymbolicLinkTarget());
+            return Directory.Exists(directoryInfo.GetSymbolicLinkTarget());
         }
 
         /// <summary>

--- a/SymbolicLinkSupport/DirectoryInfoExtensions.cs
+++ b/SymbolicLinkSupport/DirectoryInfoExtensions.cs
@@ -14,10 +14,20 @@ namespace SymbolicLinkSupport
         /// <param name="directoryInfo">the source directory for the symbolic link.</param>
         /// <param name="path">the path of the symbolic link.</param>
         /// <param name="makeTargetPathRelative">whether the target should be made relative to the symbolic link. Default <c>false</c>.</param>
-        public static void CreateSymbolicLink(this DirectoryInfo directoryInfo, string path, bool makeTargetPathRelative = false)
+        public static void CreateSymbolicLink(this DirectoryInfo directoryInfo, string path, bool makeTargetPathRelative)
         {
             SymbolicLink.CreateDirectoryLink(path, directoryInfo.FullName, makeTargetPathRelative);
         }
+
+        /// <summary>
+        /// Creates a symbolic link to this directory at the specified path.
+        /// </summary>
+        /// <param name="directoryInfo">the source directory for the symbolic link.</param>
+        /// <param name="path">the path of the symbolic link.</param>
+        public static void CreateSymbolicLink(this DirectoryInfo directoryInfo, string path)
+        {
+            directoryInfo.CreateSymbolicLink(path, false);
+        }        
 
         /// <summary>
         /// Determines whether this directory is a symbolic link.

--- a/SymbolicLinkSupport/DirectoryInfoExtensions.cs
+++ b/SymbolicLinkSupport/DirectoryInfoExtensions.cs
@@ -13,9 +13,10 @@ namespace SymbolicLinkSupport
         /// </summary>
         /// <param name="directoryInfo">the source directory for the symbolic link.</param>
         /// <param name="path">the path of the symbolic link.</param>
-        public static void CreateSymbolicLink(this DirectoryInfo directoryInfo, string path)
+        /// <param name="makeTargetPathRelative">whether the target should be made relative to the symbolic link. Default <c>false</c>.</param>
+        public static void CreateSymbolicLink(this DirectoryInfo directoryInfo, string path, bool makeTargetPathRelative = false)
         {
-            SymbolicLink.CreateDirectoryLink(path, directoryInfo.FullName);
+            SymbolicLink.CreateDirectoryLink(path, directoryInfo.FullName, makeTargetPathRelative);
         }
 
         /// <summary>

--- a/SymbolicLinkSupport/FileInfoExtensions.cs
+++ b/SymbolicLinkSupport/FileInfoExtensions.cs
@@ -13,9 +13,10 @@ namespace SymbolicLinkSupport
         /// </summary>
         /// <param name="it">the source file for the symbolic link.</param>
         /// <param name="path">the path of the symbolic link.</param>
-        public static void CreateSymbolicLink(this FileInfo it, string path)
+        /// <param name="makeTargetPathRelative">whether the target should be made relative to the symbolic link. Default <c>false</c>.</param>
+        public static void CreateSymbolicLink(this FileInfo it, string path, bool makeTargetPathRelative = false)
         {
-            SymbolicLink.CreateFileLink(path, it.FullName);
+            SymbolicLink.CreateFileLink(path, it.FullName, makeTargetPathRelative);
         }
 
         /// <summary>

--- a/SymbolicLinkSupport/FileInfoExtensions.cs
+++ b/SymbolicLinkSupport/FileInfoExtensions.cs
@@ -14,9 +14,19 @@ namespace SymbolicLinkSupport
         /// <param name="it">the source file for the symbolic link.</param>
         /// <param name="path">the path of the symbolic link.</param>
         /// <param name="makeTargetPathRelative">whether the target should be made relative to the symbolic link. Default <c>false</c>.</param>
-        public static void CreateSymbolicLink(this FileInfo it, string path, bool makeTargetPathRelative = false)
+        public static void CreateSymbolicLink(this FileInfo it, string path, bool makeTargetPathRelative)
         {
             SymbolicLink.CreateFileLink(path, it.FullName, makeTargetPathRelative);
+        }
+
+        /// <summary>
+        /// Creates a symbolic link to this file at the specified path.
+        /// </summary>
+        /// <param name="it">the source file for the symbolic link.</param>
+        /// <param name="path">the path of the symbolic link.</param>
+        public static void CreateSymbolicLink(this FileInfo it, string path)
+        {
+            it.CreateSymbolicLink(path, false);
         }
 
         /// <summary>

--- a/SymbolicLinkSupport/SymbolicLink.cs
+++ b/SymbolicLinkSupport/SymbolicLink.cs
@@ -11,6 +11,14 @@ namespace SymbolicLinkSupport
         private const uint genericReadAccess = 0x80000000;
 
         private const uint fileFlagsForOpenReparsePointAndBackupSemantics = 0x02200000;
+        /// <summary>
+        /// Flag to indicate that the reparse point is relative
+        /// </summary>
+        /// <remarks>
+        /// This is SYMLINK_FLAG_RELATIVE from from ntifs.h
+        /// See https://msdn.microsoft.com/en-us/library/cc232006.aspx
+        /// </remarks>
+        private const uint symlinkReparsePointFlagRelative = 0x00000001;
 
         private const int ioctlCommandGetReparsePoint = 0x000900A8;
 
@@ -25,6 +33,20 @@ namespace SymbolicLinkSupport
         private const int targetIsAFile = 0;
 
         private const int targetIsADirectory = 1;
+
+        /// <summary>
+        /// The maximum number of characters for a relative path, using Unicode 2-byte characters.
+        /// </summary>
+        /// <remarks>
+        /// <para>This is the same as the old MAX_PATH value, because:</para>
+        /// <para>
+        /// "you cannot use the "\\?\" prefix with a relative path, relative paths are always limited to a total of MAX_PATH characters"
+        /// </para>
+        /// (https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation)
+        /// 
+        /// This value includes allowing for a terminating null character.
+        /// </remarks>
+        private const int maxRelativePathLengthUnicodeChars = 260;
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern SafeFileHandle CreateFile(
@@ -50,8 +72,22 @@ namespace SymbolicLinkSupport
             out int lpBytesReturned,
             IntPtr lpOverlapped);
 
-        public static void CreateDirectoryLink(string linkPath, string targetPath)
+        [DllImport("shlwapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        static extern bool PathRelativePathToW(
+            StringBuilder pszPath,
+            string pszFrom,
+            FileAttributes dwAttrFrom,
+            string pszTo,
+            FileAttributes dwAttrTo);
+
+
+        public static void CreateDirectoryLink(string linkPath, string targetPath, bool makeTargetPathRelative = false)
         {
+            if (makeTargetPathRelative)
+            {
+                targetPath = GetTargetPathRelativeToLink(linkPath, targetPath, true);
+            }
+
             if (!CreateSymbolicLink(linkPath, targetPath, targetIsADirectory) || Marshal.GetLastWin32Error() != 0)
             {
                 try
@@ -65,12 +101,46 @@ namespace SymbolicLinkSupport
             }
         }
 
-        public static void CreateFileLink(string linkPath, string targetPath)
+        public static void CreateFileLink(string linkPath, string targetPath, bool makeTargetPathRelative = false)
         {
+            if (makeTargetPathRelative)
+            {
+                targetPath = GetTargetPathRelativeToLink(linkPath, targetPath);
+            }
+
             if (!CreateSymbolicLink(linkPath, targetPath, targetIsAFile))
             {
                 Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
             }
+        }
+        
+        public static string GetTargetPathRelativeToLink(string linkPath, string targetPath, bool linkAndTargetAreDirectories = false)
+        {
+            string returnPath;
+
+            FileAttributes relativePathAttribute = 0;
+            if (linkAndTargetAreDirectories)
+            {
+                relativePathAttribute = FileAttributes.Directory;
+
+                // set the link path to the parent directory, so that PathRelativePathToW returns a path that works
+                // for directory symlink traversal
+                linkPath = Path.GetDirectoryName(linkPath.TrimEnd(Path.DirectorySeparatorChar));
+            }
+            
+            StringBuilder relativePath = new StringBuilder(maxRelativePathLengthUnicodeChars);
+            if (!PathRelativePathToW(relativePath, linkPath, relativePathAttribute, targetPath, relativePathAttribute))
+            {
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                returnPath = targetPath;
+            }
+            else
+            {
+                returnPath = relativePath.ToString();
+            }
+
+            return returnPath;
+
         }
 
         public static bool Exists(string path)
@@ -142,6 +212,13 @@ namespace SymbolicLinkSupport
 
             string target = Encoding.Unicode.GetString(reparseDataBuffer.PathBuffer,
                 reparseDataBuffer.PrintNameOffset, reparseDataBuffer.PrintNameLength);
+
+            if ((reparseDataBuffer.Flags & symlinkReparsePointFlagRelative) == symlinkReparsePointFlagRelative)
+            {
+                string basePath = Path.GetDirectoryName(path.TrimEnd(Path.DirectorySeparatorChar));
+                string combinedPath = Path.Combine(basePath, target);
+                target = Path.GetFullPath(combinedPath);
+            }
 
             return target;
         }

--- a/SymbolicLinkSupport/SymbolicLink.cs
+++ b/SymbolicLinkSupport/SymbolicLink.cs
@@ -80,8 +80,12 @@ namespace SymbolicLinkSupport
             string pszTo,
             FileAttributes dwAttrTo);
 
+        public static void CreateDirectoryLink(string linkPath, string targetPath)
+        {
+            CreateDirectoryLink(linkPath, targetPath, false);
+        }
 
-        public static void CreateDirectoryLink(string linkPath, string targetPath, bool makeTargetPathRelative = false)
+        public static void CreateDirectoryLink(string linkPath, string targetPath, bool makeTargetPathRelative)
         {
             if (makeTargetPathRelative)
             {
@@ -101,7 +105,12 @@ namespace SymbolicLinkSupport
             }
         }
 
-        public static void CreateFileLink(string linkPath, string targetPath, bool makeTargetPathRelative = false)
+        public static void CreateFileLink(string linkPath, string targetPath)
+        {
+            CreateFileLink(linkPath, targetPath, false);
+        }
+        
+        public static void CreateFileLink(string linkPath, string targetPath, bool makeTargetPathRelative)
         {
             if (makeTargetPathRelative)
             {
@@ -114,7 +123,7 @@ namespace SymbolicLinkSupport
             }
         }
         
-        public static string GetTargetPathRelativeToLink(string linkPath, string targetPath, bool linkAndTargetAreDirectories = false)
+        private static string GetTargetPathRelativeToLink(string linkPath, string targetPath, bool linkAndTargetAreDirectories = false)
         {
             string returnPath;
 

--- a/SymbolicLinkSupport/SymbolicLinkReparseData.cs
+++ b/SymbolicLinkSupport/SymbolicLinkReparseData.cs
@@ -19,7 +19,9 @@ namespace SymbolicLinkSupport
         public ushort PrintNameOffset;
         public ushort PrintNameLength;
         public uint Flags;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = maxUnicodePathLength)]
+        // PathBuffer needs to be able to contain both SubstituteName and PrintName,
+        // so needs to be 2 * maximum of each
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = maxUnicodePathLength * 2)]
         public byte[] PathBuffer;
     }
 }

--- a/SymbolicLinkSupport/SymbolicLinkSupport.csproj
+++ b/SymbolicLinkSupport/SymbolicLinkSupport.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net35;netstandard1.3</TargetFrameworks>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Description>A library that provides extension methods for System.IO.FileInfo and System.IO.DirectoryInfo to support symbolic links using the code from Troy Parsons' blog post http://troyparsons.com/blog/2012/03/symbolic-links-in-c-sharp/.</Description>
     <Authors>Michael Melancon</Authors>
     <PackageTags>symlink, extension method, symbolic link</PackageTags>
     <PackageProjectUrl>https://github.com/michaelmelancon/symboliclinksupport.git</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/michaelmelancon/symboliclinksupport/blob/master/LICENSE.md</PackageLicenseUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeDocumentationProjectOutputGroup>True</IncludeDocumentationProjectOutputGroup>
+    <DocumentationFile Condition="'$(Configuration)'=='Release'">bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Prevented breaking change by adding overloads instead of adding default parameters to existing methods.
- Prevented a helper method from the being exposed in the public API.
- Performed a minor version bump.
